### PR TITLE
Set main to index.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "convert-source-map",
   "version": "0.2.5",
   "description": "Converts a source-map from/to  different formats and allows adding/changing properties.",
-  "main": "convert-source-map.js",
+  "main": "index.js",
   "scripts": {
     "test": "node-trap test/*.js"
   },


### PR DESCRIPTION
Minor change to make the main field in the package.json point to the right file, index.js.

Much like the issue that I reported earlier in brace:
  https://github.com/thlorenz/brace/pull/1
