### PR TITLE
Remove logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ function Converter (sm, opts) {
 
     this.sourcemap = sm;
   } catch(e) {
-    console.error(e);
     return null;
   }
 }


### PR DESCRIPTION
I can see why this is here, but it's not great that you can't catch logging, especially when you're consuming this module. Maybe an event emitter or just throwing would be better?