### PR TITLE
Fromsource

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ Returns source map converter from given `filename` by parsing `//# sourceMapping
 `filename` must point to a file that is found inside the `mapFileDir`. Most tools store this file right next to the
 generated file, i.e. the one containing the source map.
 
-### fromSource(source)
+### fromSource(source[, largeSource])
 
-Finds last sourcemap comment in file and returns source map converter or returns null if no source map comment was
-found.
+Finds last sourcemap comment in file and returns source map converter or returns null if no source map comment was found.
+
+If `largeSource` is set to `true`, an algorithm that does not use regex is applied to find the source map. This is faster and especially useful if you're running into "call stack size exceeded" errors with the default algorithm.
+
+However, it is less accurate and may match content that isn't a source map comment.
 
 ### fromMapFileSource(source, mapFileDir)
 

--- a/index.js
+++ b/index.js
@@ -47,14 +47,20 @@ function Converter (sm, opts) {
   }
 }
 
-function findLastSourceMapComment(comment, line){
-  if (line.indexOf('sourceMappingURL=data:') > -1) comment = line;
-  return comment;
-};
-
 function convertFromLargeSource(content){
-  var comment = content.split('\n').reduce(findLastSourceMapComment, '')
-  return comment ? exports.fromComment(comment) : null;
+  var lines = content.split('\n');
+  var lineNumber;
+  var line;
+
+  // starting with the last line, look for the source map comment
+  for (lineNumber = lines.length - 1; lineNumber > 0; lineNumber--){
+    line = lines[lineNumber]
+
+    // if the line looks like a sourcemap comment, convert it and return to bail
+    if (line.indexOf('sourceMappingURL=data:') > -1) {
+      return exports.fromComment(line)
+    }
+  }
 };
 
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ function findLastSourceMapComment(comment, line){
 };
 
 function convertFromLargeSource(content){
-  return content.split('\n').reduce(findLastSourceMapComment, '');
+  var comment = content.split('\n').reduce(findLastSourceMapComment, '')
+  return comment ? exports.fromComment(comment) : null;
 };
 
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,16 @@ function Converter (sm, opts) {
   }
 }
 
+function findLastSourceMapComment(comment, line){
+  if (line.indexOf('sourceMappingURL=data:') > -1) comment = line;
+  return comment;
+};
+
+function convertFromLargeSource(content){
+  return content.split('\n').reduce(findLastSourceMapComment, '');
+};
+
+
 Converter.prototype.toJSON = function (space) {
   return JSON.stringify(this.sourcemap, null, space);
 };
@@ -105,8 +115,12 @@ exports.fromMapFileComment = function (comment, dir) {
 };
 
 // Finds last sourcemap comment in file or returns null if none was found
-exports.fromSource = function (content) {
-  var m = content.match(commentRx);
+exports.fromSource = function (content, largeSource) {
+  var m;
+
+  if (largeSource) return convertFromLargeSource(content);
+
+  m = content.match(commentRx);
   commentRx.lastIndex = 0;
   return m ? exports.fromComment(m.pop()) : null;
 };

--- a/test/convert-source-map.js
+++ b/test/convert-source-map.js
@@ -68,6 +68,33 @@ test('from source', function (t) {
   t.end()
 })
 
+test('from source with a large source', function (t) {
+  var foo = [
+      'function foo() {'
+    , ' console.log("hello I am foo");'
+    , ' console.log("who are you");'
+    , '}'
+    , ''
+    , 'foo();'
+    , ''
+    ].join('\n')
+  , map = '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmdW5jdGlvbiBmb28oKSB7XG4gY29uc29sZS5sb2coXCJoZWxsbyBJIGFtIGZvb1wiKTtcbiBjb25zb2xlLmxvZyhcIndobyBhcmUgeW91XCIpO1xufVxuXG5mb28oKTtcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9'
+  , otherMap = '//# sourceMappingURL=data:application/json;base64,otherZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmdW5jdGlvbiBmb28oKSB7XG4gY29uc29sZS5sb2coXCJoZWxsbyBJIGFtIGZvb1wiKTtcbiBjb25zb2xlLmxvZyhcIndobyBhcmUgeW91XCIpO1xufVxuXG5mb28oKTtcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9'
+
+  function getComment(src) {
+    var map = convert.fromSource(src, true);
+    return map ? map.toComment() : null;
+  }
+
+  t.equal(getComment(foo), null, 'no comment returns null')
+  t.equal(getComment(foo + map), map, 'beginning of last line')
+  t.equal(getComment(foo + '    ' +  map), map, 'indented of last line')
+  t.equal(getComment(foo + '   ' + map + '\n\n'), map, 'indented on last non empty line')
+  t.equal(getComment(foo + map + '\nconsole.log("more code");\nfoo()\n'), map, 'in the middle of code')
+  t.equal(getComment(foo + otherMap + '\n' +  map), map, 'finds last map in source')
+  t.end()
+})
+
 test('remove comments', function (t) {
   var foo = [
       'function foo() {'


### PR DESCRIPTION
Replaces #16 

Using a regex to match against very long files can cause the process to run out of memory with a "call stack size exceeded" error. This switches from a regex match to a `indexOf` match. It's slightly less accurate (prone to false-positives), but this shouldn't matter because, 1) the source map we care about is always at the end of the file, 2) it's unlikely enough this precise string would appear in any code.