### PR TITLE
adding support for outputting multi-line comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,9 +66,10 @@ Converter.prototype.toBase64 = function () {
   return new Buffer(json).toString('base64');
 };
 
-Converter.prototype.toComment = function () {
+Converter.prototype.toComment = function (options) {
   var base64 = this.toBase64();
-  return '//# sourceMappingURL=data:application/json;base64,' + base64;
+  var data = 'sourceMappingURL=data:application/json;base64,' + base64;
+  return options && options.multiline ? '/*# ' + data + ' */' : '//# ' + data;
 };
 
 // returns copy instead of original

--- a/test/convert-source-map.js
+++ b/test/convert-source-map.js
@@ -41,6 +41,13 @@ test('to object returns a copy', function (t) {
   t.end()
 })
 
+test('to multi-line map', function (t) {
+  var c = convert.fromObject(obj);
+  var s = c.toComment({ multiline: true });
+  t.similar(s, /^\/\*# sourceMappingURL=.+ \*\/$/);
+  t.end();
+})
+
 test('from source', function (t) {
   var foo = [
       'function foo() {'


### PR DESCRIPTION
Attempt 2 at adding support for generating multi-line comments. API changes include:

**convert.toComment([options])**

The new `options` object only has 1 recognized property, which is `multiline`. When that property is truthy, it will output the comment using multi-line syntax. (ie: `/*# sourceMappingURL=... */`)

This was added with support for CSS in mind, but I'm sure other applications exist.