### PR TITLE
No longer swallowing parse errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,17 +34,13 @@ function readFromFileMap(sm, dir) {
 
 function Converter (sm, opts) {
   opts = opts || {};
-  try {
-    if (opts.isFileComment) sm = readFromFileMap(sm, opts.commentFileDir);
-    if (opts.hasComment) sm = stripComment(sm);
-    if (opts.isEncoded) sm = decodeBase64(sm);
-    if (opts.isJSON || opts.isEncoded) sm = JSON.parse(sm);
 
-    this.sourcemap = sm;
-  } catch(e) {
-    console.error(e);
-    return null;
-  }
+  if (opts.isFileComment) sm = readFromFileMap(sm, opts.commentFileDir);
+  if (opts.hasComment) sm = stripComment(sm);
+  if (opts.isEncoded) sm = decodeBase64(sm);
+  if (opts.isJSON || opts.isEncoded) sm = JSON.parse(sm);
+
+  this.sourcemap = sm;
 }
 
 function convertFromLargeSource(content){


### PR DESCRIPTION
In response to #17, this removes the `try...catch` around the `Converter` constructor logic. This will now force callers to check for exceptions, but it allows them to handle it in whatever way is appropriate for them.

This will be a **breaking** API change that will require a bump to the `major` version.

/cc @thlorenz @matthewmueller