### PR TITLE
IE9 fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,12 +137,12 @@ exports.removeMapFileComments = function (src) {
   return src.replace(mapFileCommentRx, '');
 };
 
-Object.defineProperty(exports, 'commentRegex', function () {
+Object.defineProperty(exports, 'commentRegex', {get: function () {
   commentRx.lastIndex = 0;
   return commentRx; 
-});
+}});
 
-Object.defineProperty(exports, 'mapFileCommentRegex', function () {
+Object.defineProperty(exports, 'mapFileCommentRegex', {get: function () {
   mapFileCommentRx.lastIndex = 0;
   return mapFileCommentRx; 
-});
+}});

--- a/index.js
+++ b/index.js
@@ -139,10 +139,10 @@ exports.removeMapFileComments = function (src) {
 
 Object.defineProperty(exports, 'commentRegex', function () {
   commentRx.lastIndex = 0;
-  return commentRx;
+  return commentRx; 
 });
 
 Object.defineProperty(exports, 'mapFileCommentRegex', function () {
-    mapFileCommentRx.lastIndex = 0;
-    return mapFileCommentRx;
+  mapFileCommentRx.lastIndex = 0;
+  return mapFileCommentRx; 
 });

--- a/index.js
+++ b/index.js
@@ -4,145 +4,145 @@ var path = require('path');
 
 var commentRx = /^\s*\/(?:\/|\*)[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+;)?base64,(.*)$/mg;
 var mapFileCommentRx =
-  // //# sourceMappingURL=foo.js.map                       /*# sourceMappingURL=foo.js.map */
-  /(?:\/\/[@#][ \t]+sourceMappingURL=(.+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/){1}[ \t]*$)/mg
+    // //# sourceMappingURL=foo.js.map                       /*# sourceMappingURL=foo.js.map */
+    /(?:\/\/[@#][ \t]+sourceMappingURL=(.+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/){1}[ \t]*$)/mg
 
 function decodeBase64(base64) {
-  return new Buffer(base64, 'base64').toString();
+    return new Buffer(base64, 'base64').toString();
 }
 
 function stripComment(sm) {
-  return sm.split(',').pop();
+    return sm.split(',').pop();
 }
 
 function readFromFileMap(sm, dir) {
-  // NOTE: this will only work on the server since it attempts to read the map file
+    // NOTE: this will only work on the server since it attempts to read the map file
 
-  var r = mapFileCommentRx.exec(sm);
-  mapFileCommentRx.lastIndex = 0;
-  
-  // for some odd reason //# .. captures in 1 and /* .. */ in 2
-  var filename = r[1] || r[2];
-  var filepath = path.join(dir, filename);
+    var r = mapFileCommentRx.exec(sm);
+    mapFileCommentRx.lastIndex = 0;
 
-  try {
-    return fs.readFileSync(filepath, 'utf8');
-  } catch (e) {
-    throw new Error('An error occurred while trying to read the map file at ' + filepath + '\n' + e);
-  }
+    // for some odd reason //# .. captures in 1 and /* .. */ in 2
+    var filename = r[1] || r[2];
+    var filepath = path.join(dir, filename);
+
+    try {
+        return fs.readFileSync(filepath, 'utf8');
+    } catch (e) {
+        throw new Error('An error occurred while trying to read the map file at ' + filepath + '\n' + e);
+    }
 }
 
-function Converter (sm, opts) {
-  opts = opts || {};
+function Converter(sm, opts) {
+    opts = opts || {};
 
-  if (opts.isFileComment) sm = readFromFileMap(sm, opts.commentFileDir);
-  if (opts.hasComment) sm = stripComment(sm);
-  if (opts.isEncoded) sm = decodeBase64(sm);
-  if (opts.isJSON || opts.isEncoded) sm = JSON.parse(sm);
+    if (opts.isFileComment) sm = readFromFileMap(sm, opts.commentFileDir);
+    if (opts.hasComment) sm = stripComment(sm);
+    if (opts.isEncoded) sm = decodeBase64(sm);
+    if (opts.isJSON || opts.isEncoded) sm = JSON.parse(sm);
 
-  this.sourcemap = sm;
+    this.sourcemap = sm;
 }
 
-function convertFromLargeSource(content){
-  var lines = content.split('\n');
-  var line;
-  // find first line which contains a source map starting at end of content 
-  for (var i = lines.length - 1; i > 0; i--) {
-    line = lines[i]
-    if (~line.indexOf('sourceMappingURL=data:')) return exports.fromComment(line);
-  }
+function convertFromLargeSource(content) {
+    var lines = content.split('\n');
+    var line;
+    // find first line which contains a source map starting at end of content
+    for (var i = lines.length - 1; i > 0; i--) {
+        line = lines[i]
+        if (~line.indexOf('sourceMappingURL=data:')) return exports.fromComment(line);
+    }
 }
 
 Converter.prototype.toJSON = function (space) {
-  return JSON.stringify(this.sourcemap, null, space);
+    return JSON.stringify(this.sourcemap, null, space);
 };
 
 Converter.prototype.toBase64 = function () {
-  var json = this.toJSON();
-  return new Buffer(json).toString('base64');
+    var json = this.toJSON();
+    return new Buffer(json).toString('base64');
 };
 
 Converter.prototype.toComment = function (options) {
-  var base64 = this.toBase64();
-  var data = 'sourceMappingURL=data:application/json;base64,' + base64;
-  return options && options.multiline ? '/*# ' + data + ' */' : '//# ' + data;
+    var base64 = this.toBase64();
+    var data = 'sourceMappingURL=data:application/json;base64,' + base64;
+    return options && options.multiline ? '/*# ' + data + ' */' : '//# ' + data;
 };
 
 // returns copy instead of original
 Converter.prototype.toObject = function () {
-  return JSON.parse(this.toJSON());
+    return JSON.parse(this.toJSON());
 };
 
 Converter.prototype.addProperty = function (key, value) {
-  if (this.sourcemap.hasOwnProperty(key)) throw new Error('property %s already exists on the sourcemap, use set property instead');
-  return this.setProperty(key, value);
+    if (this.sourcemap.hasOwnProperty(key)) throw new Error('property %s already exists on the sourcemap, use set property instead');
+    return this.setProperty(key, value);
 };
 
 Converter.prototype.setProperty = function (key, value) {
-  this.sourcemap[key] = value;
-  return this;
+    this.sourcemap[key] = value;
+    return this;
 };
 
 Converter.prototype.getProperty = function (key) {
-  return this.sourcemap[key];
+    return this.sourcemap[key];
 };
 
 exports.fromObject = function (obj) {
-  return new Converter(obj);
+    return new Converter(obj);
 };
 
 exports.fromJSON = function (json) {
-  return new Converter(json, { isJSON: true });
+    return new Converter(json, {isJSON: true});
 };
 
 exports.fromBase64 = function (base64) {
-  return new Converter(base64, { isEncoded: true });
+    return new Converter(base64, {isEncoded: true});
 };
 
 exports.fromComment = function (comment) {
-  comment = comment
-    .replace(/^\/\*/g, '//')
-    .replace(/\*\/$/g, '');
+    comment = comment
+        .replace(/^\/\*/g, '//')
+        .replace(/\*\/$/g, '');
 
-  return new Converter(comment, { isEncoded: true, hasComment: true });
+    return new Converter(comment, {isEncoded: true, hasComment: true});
 };
 
 exports.fromMapFileComment = function (comment, dir) {
-  return new Converter(comment, { commentFileDir: dir, isFileComment: true, isJSON: true });
+    return new Converter(comment, {commentFileDir: dir, isFileComment: true, isJSON: true});
 };
 
 // Finds last sourcemap comment in file or returns null if none was found
 exports.fromSource = function (content, largeSource) {
-  if (largeSource) return convertFromLargeSource(content);
+    if (largeSource) return convertFromLargeSource(content);
 
-  var m = content.match(commentRx);
-  commentRx.lastIndex = 0;
-  return m ? exports.fromComment(m.pop()) : null;
+    var m = content.match(commentRx);
+    commentRx.lastIndex = 0;
+    return m ? exports.fromComment(m.pop()) : null;
 };
 
 // Finds last sourcemap comment in file or returns null if none was found
 exports.fromMapFileSource = function (content, dir) {
-  var m = content.match(mapFileCommentRx);
-  mapFileCommentRx.lastIndex = 0;
-  return m ? exports.fromMapFileComment(m.pop(), dir) : null;
+    var m = content.match(mapFileCommentRx);
+    mapFileCommentRx.lastIndex = 0;
+    return m ? exports.fromMapFileComment(m.pop(), dir) : null;
 };
 
 exports.removeComments = function (src) {
-  commentRx.lastIndex = 0;
-  return src.replace(commentRx, '');
+    commentRx.lastIndex = 0;
+    return src.replace(commentRx, '');
 };
 
 exports.removeMapFileComments = function (src) {
-  mapFileCommentRx.lastIndex = 0;
-  return src.replace(mapFileCommentRx, '');
+    mapFileCommentRx.lastIndex = 0;
+    return src.replace(mapFileCommentRx, '');
 };
 
-Object.defineProperty(exports, 'commentRegex', {get: function () {
-  commentRx.lastIndex = 0;
-  return commentRx; 
-}});
+Object.defineProperty(exports, 'commentRegex', function getCommentRegex() {
+    commentRx.lastIndex = 0;
+    return commentRx;
+});
 
-Object.defineProperty(exports, 'mapFileCommentRegex', {get: function () {
-  mapFileCommentRx.lastIndex = 0;
-  return mapFileCommentRx; 
-}});
+Object.defineProperty(exports, 'mapFileCommentRegex', function getMapFileCommentRegex () {
+    mapFileCommentRx.lastIndex = 0;
+    return mapFileCommentRx;
+});

--- a/index.js
+++ b/index.js
@@ -137,12 +137,12 @@ exports.removeMapFileComments = function (src) {
   return src.replace(mapFileCommentRx, '');
 };
 
-exports.__defineGetter__('commentRegex', function () {
+Object.defineProperty(exports, 'commentRegex', function () {
   commentRx.lastIndex = 0;
-  return commentRx; 
+  return commentRx;
 });
 
-exports.__defineGetter__('mapFileCommentRegex', function () {
-  mapFileCommentRx.lastIndex = 0;
-  return mapFileCommentRx; 
+Object.defineProperty(exports, 'mapFileCommentRegex', function () {
+    mapFileCommentRx.lastIndex = 0;
+    return mapFileCommentRx;
 });


### PR DESCRIPTION
This PR fixes problems with IE9. It replaces non-standard and depreciated [`__defineGetter__`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)  with standard [`Object.defineProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty). The patch has been tested on:

Internet Explorer 11
Internet Explorer 10
Internet Explorer 9
Chrome 41.0
Firefox 36.0.1
Safari 8.0.5
Opera 27.0
