### PR TITLE
Don't match leading text in "mapFileCommentRx"

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 var commentRx = /^\s*\/(?:\/|\*)[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+;)?base64,(.*)$/mg;
 var mapFileCommentRx =
   // //# sourceMappingURL=foo.js.map                       /*# sourceMappingURL=foo.js.map */
-  /(?:\/\/[@#][ \t]+sourceMappingURL=(.+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/){1}[ \t]*$)/mg
+  /(?:^\s*\/\/[@#][ \t]+sourceMappingURL=(.+?)[ \t]*$)|(?:^\s*\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/){1}[ \t]*$)/mg
 
 function decodeBase64(base64) {
   return new Buffer(base64, 'base64').toString();

--- a/test/comment-regex.js
+++ b/test/comment-regex.js
@@ -75,12 +75,12 @@ test('mapFileComment regex old spec - @', function (t) {
   [ 
     '//@ ',
     '  //@ ',
-    '\t//@ ',
-    '///@ ',
+    '\t//@ '
   ].forEach(function (x) { t.ok(mapFileComment(x), 'matches ' + x) });
 
   [ 
     ' @// @',
+    '///@ '   // with leading text
   ].forEach(function (x) { t.ok(!mapFileComment(x), 'does not match ' + x) })
   t.end()
 })
@@ -89,12 +89,12 @@ test('mapFileComment regex new spec - #', function (t) {
   [ 
     '//@ ',
     '  //@ ', // with leading space
-    '\t//@ ', // with leading tab
-    '//@ ', // with leading text
+    '\t//@ '  // with leading tab
   ].forEach(function (x) { t.ok(mapFileComment(x), 'matches ' + x) });
 
   [ 
     ' #// #',
+    '"//@ '   // with leading text
   ].forEach(function (x) { t.ok(!mapFileComment(x), 'does not match ' + x) })
   t.end()
 })
@@ -108,12 +108,12 @@ test('mapFileComment regex /* */ old spec - @', function (t) {
   [ [ '/*@ ', '*/' ]
   , ['  /*@ ', '  */ ' ]            // with leading spaces
   , [ '\t/*@ ', ' \t*/\t ']         // with a leading tab
-  , [ 'leading string/*@ ', '*/' ]  // with a leading string
   , [ '/*@ ', ' \t*/\t ']           // with trailing whitespace
   ].forEach(function (x) { t.ok(mapFileCommentWrap(x[0], x[1]), 'matches ' + x.join(' :: ')) });
 
-  [ ['/*@ ', ' */ */ ' ],       // not the last thing on its line 
-    ['/*@ ', ' */ more text ' ] // not the last thing on its line 
+  [ ['/*@ ', ' */ */ ' ]            // not the last thing on its line 
+  , ['/*@ ', ' */ more text ' ]     // not the last thing on its line 
+  , [ 'leading string/*@ ', '*/' ]  // with a leading string
   ].forEach(function (x) { t.ok(!mapFileCommentWrap(x[0], x[1]), 'does not match ' + x.join(' :: ')) });
   t.end()
 })
@@ -122,12 +122,12 @@ test('mapFileComment regex /* */ new spec - #', function (t) {
   [ [ '/*# ', '*/' ]
   , ['  /*# ', '  */ ' ]            // with leading spaces
   , [ '\t/*# ', ' \t*/\t ']         // with a leading tab
-  , [ 'leading string/*# ', '*/' ]  // with a leading string
   , [ '/*# ', ' \t*/\t ']           // with trailing whitespace
   ].forEach(function (x) { t.ok(mapFileCommentWrap(x[0], x[1]), 'matches ' + x.join(' :: ')) });
 
-  [ ['/*# ', ' */ */ ' ],       // not the last thing on its line 
-    ['/*# ', ' */ more text ' ] // not the last thing on its line 
+  [ ['/*# ', ' */ */ ' ]            // not the last thing on its line 
+  , ['/*# ', ' */ more text ' ]     // not the last thing on its line 
+  , [ 'leading string/*# ', '*/' ]  // with a leading string
   ].forEach(function (x) { t.ok(!mapFileCommentWrap(x[0], x[1]), 'does not match ' + x.join(' :: ')) });
   t.end()
 })


### PR DESCRIPTION
Sorry @thlorenz, more browserify breakage :cry: `mapFileCommentRx` is also grabbing leading text, which is causing combine-source-map's `removeComments()` to turn this:

```js
var str = "foo//# sourceMappingURL=data:application/json;charset:utf-8;base64,abc";
console.log('Hello world', str.length);
```

into this:

```js
var str = "foo
console.log('Hello world', str.length);
```

The tests were setup to allow this - am I missing something?