### PR TITLE
adding a utility fn for generating a map file comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,13 @@ Returns the regex used to find source map comments.
 
 Returns the regex used to find source map comments pointing to map files.
 
+### generateMapFileComment(file, [options])
+
+Returns a comment that links to an external source map via `file`.
+
+By default, the comment is formatted like: `//# sourceMappingURL=...`, which you would normally see in a JS source file.
+
+When `options.multiline == true`, the comment is formatted like: `/*# sourceMappingURL=... */`, which you would find in a CSS source file.
+
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/thlorenz/convert-source-map/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/index.js
+++ b/index.js
@@ -141,6 +141,11 @@ exports.removeMapFileComments = function (src) {
   return src.replace(mapFileCommentRx, '');
 };
 
+exports.generateMapFileComment = function (file, options) {
+  var data = 'sourceMappingURL=' + file;
+  return options && options.multiline ? '/*# ' + data + ' */' : '//# ' + data;
+};
+
 Object.defineProperty(exports, 'commentRegex', {
   get: function getCommentRegex () {
     commentRx.lastIndex = 0;

--- a/test/convert-source-map.js
+++ b/test/convert-source-map.js
@@ -48,6 +48,12 @@ test('to multi-line map', function (t) {
   t.end();
 })
 
+test('to map file comment', function (t) {
+  t.equal(convert.generateMapFileComment('index.js.map'), '//# sourceMappingURL=index.js.map');
+  t.equal(convert.generateMapFileComment('index.css.map', { multiline: true }), '/*# sourceMappingURL=index.css.map */');
+  t.end();
+})
+
 test('from source', function (t) {
   var foo = [
       'function foo() {'


### PR DESCRIPTION
This is just a little helper utility I just feel belongs in a library like this. (and find myself re-implementing all the time) When working with external source-maps, it's nice to have a little fn to generate the comment rather than composing that string manually:

```js
convert.mapFileComment('index.js.map');
// => //# sourceMappingURL=index.js.map

convert.mapFileComment('index.css.map', { multiline: true });
// => /*# sourceMappingURL=index.css.map */
```

This PR includes tests, but let me know if there's anything else you'd like to change in order to land this.