### PR TITLE
Allow comments to contain absolute paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function readFromFileMap(sm, dir) {
 
   // for some odd reason //# .. captures in 1 and /* .. */ in 2
   var filename = r[1] || r[2];
-  var filepath = path.join(dir, filename);
+  var filepath = path.resolve(dir, filename);
 
   try {
     return fs.readFileSync(filepath, 'utf8');


### PR DESCRIPTION
Using `path.resolve` instead of `path.join` allows for absolute paths on Windows. The Node.js documentation does not provide a clear reason why, but I have verified this solves my issue.

You can prove this to yourself with the following command:

```
$ node -e "console.log(path.win32.join('C:\\foo\\bar', 'D:\\baz\\quz.js'));"
$ node -e "console.log(path.win32.resolve('C:\\foo\\bar', 'D:\\baz\\quz.js'));"
```