### PR TITLE
Make sure 'sourceMappingURL' example does not match 'mapFileCommentRx'

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 var commentRx = /^\s*\/(?:\/|\*)[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+;)?base64,(.*)$/mg;
 var mapFileCommentRx =
   //Example (Extra space between slashes added to solve Safari bug. Exclude space in production):
-  //     / /# sourceMappingURL=foo.js.map           /*# sourceMappingURL=foo.js.map */
+  ///     / /# sourceMappingURL=foo.js.map           /*# sourceMappingURL=foo.js.map */
   /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/){1}[ \t]*$)/mg
 
 function decodeBase64(base64) {


### PR DESCRIPTION
I am attempting to use [babel](https://github.com/babel/babel) within [devtool](https://github.com/Jam3/devtool), and they both use this library. Thus, this library ends up parsing itself to find any `sourceMappingURL` comments.

The only problem is that [this line](https://github.com/thlorenz/convert-source-map/blob/master/index.js#L8) exists, and it is pased by `mapFileCommentRx` as a match. Then `devtool` tries to `fs.readFileSync` that line, which results in an uncaught exception.

This PR fixes that by simply adding another `/` to the beginning of the example comment. 👍    