### PR TITLE
Fix to avoid external modules altering the RegExps used internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Returns `src` with all source map comments pointing to map files removed.
 
 ### commentRegex
 
-Returns the regex used to find source map comments.
+Provides __a fresh__ RegExp each time it is accessed. Can be used to find source map comments.
 
 ### mapFileCommentRegex
 
-Returns the regex used to find source map comments pointing to map files.
+Provides __a fresh__ RegExp each time it is accessed. Can be used to find source map comments pointing to map files.
 
 ### generateMapFileComment(file, [options])
 

--- a/test/comment-regex.js
+++ b/test/comment-regex.js
@@ -3,17 +3,16 @@
 
 var test = require('tap').test
   , generator = require('inline-source-map')
-  , rx = require('..').commentRegex
-  , mapFileRx = require('..').mapFileCommentRegex
+  , convert = require('..')
 
 function comment(prefix, suffix) {
-  rx.lastIndex = 0;
+  var rx = convert.commentRegex;
   return rx.test(prefix + 'sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmdW5jdGlvbiBmb28oKSB7XG4gY29uc29sZS5sb2coXCJoZWxsbyBJIGFtIGZvb1wiKTtcbiBjb25zb2xlLmxvZyhcIndobyBhcmUgeW91XCIpO1xufVxuXG5mb28oKTtcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9' + suffix)
 }
 
 function commentWithCharSet(prefix, suffix, sep) {
   sep = sep || ':';
-  rx.lastIndex = 0;
+  var rx = convert.commentRegex;
   return rx.test(prefix + 'sourceMappingURL=data:application/json;charset' + sep +'utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmdW5jdGlvbiBmb28oKSB7XG4gY29uc29sZS5sb2coXCJoZWxsbyBJIGFtIGZvb1wiKTtcbiBjb25zb2xlLmxvZyhcIndobyBhcmUgeW91XCIpO1xufVxuXG5mb28oKTtcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9' + suffix)
 }
 
@@ -66,7 +65,7 @@ test('comment regex new spec - #', function (t) {
 })
 
 function mapFileCommentWrap(s1, s2) {
-  mapFileRx.lastIndex = 0;
+  var mapFileRx = convert.mapFileCommentRegex;
   return mapFileRx.test(s1 + 'sourceMappingURL=foo.js.map' + s2)
 }
 

--- a/test/convert-source-map.js
+++ b/test/convert-source-map.js
@@ -211,3 +211,45 @@ test('return null fromSource when largeSource is true', function(t) {
   )
   t.end()
 })
+
+test('commentRegex returns new RegExp on each get', function(t) {
+  var foo = [
+      'function foo() {'
+    , ' console.log("hello I am foo");'
+    , ' console.log("who are you");'
+    , '}'
+    , ''
+    , 'foo();'
+    , ''
+    ].join('\n')
+  , map = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmdW5jdGlvbiBmb28oKSB7XG4gY29uc29sZS5sb2coXCJoZWxsbyBJIGFtIGZvb1wiKTtcbiBjb25zb2xlLmxvZyhcIndobyBhcmUgeW91XCIpO1xufVxuXG5mb28oKTtcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9'
+  , re = convert.commentRegex
+
+  re.exec(foo + map)
+
+  t.equal(re.lastIndex, 372, 'has an updated lastIndex')
+  t.equal(convert.commentRegex.lastIndex, 0, 'a fresh RegExp has lastIndex of 0')
+
+  t.end()
+})
+
+test('mapFileCommentRegex returns new RegExp on each get', function(t) {
+  var foo = [
+      'function foo() {'
+    , ' console.log("hello I am foo");'
+    , ' console.log("who are you");'
+    , '}'
+    , ''
+    , 'foo();'
+    , ''
+    ].join('\n')
+  , map = '//# sourceMappingURL=foo.js.map'
+  , re = convert.mapFileCommentRegex
+
+  re.exec(foo + map)
+
+  t.equal(re.lastIndex, 119, 'has an updated lastIndex')
+  t.equal(convert.mapFileCommentRegex.lastIndex, 0, 'a fresh RegExp has lastIndex of 0')
+
+  t.end()
+})


### PR DESCRIPTION
This allows the RegExps to be fresh when retrieved by the getters.  It also avoids needing to call `lastIndex` at all internally and keeps external usage of the RegExps from colliding with internal usage.  

I've added tests to ensure fresh RegExps are being returned, updated the docs to explicitly mention consumers receive fresh RegExps and updated some other tests to avoid the `lastIndex` stuff (just to remove it from the codebase, it didn't really need to happen).

@thlorenz Thanks for taking the time to look into this.