### PR TITLE
add getCommentValue and getMapFileCommentValue methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,7 @@ function stripComment(sm) {
 function readFromFileMap(sm, dir) {
   // NOTE: this will only work on the server since it attempts to read the map file
 
-  var r = exports.mapFileCommentRegex.exec(sm);
-
-  // for some odd reason //# .. captures in 1 and /* .. */ in 2
-  var filename = r[1] || r[2];
+  var filename = exports.getMapFileCommentValue(sm);
   var filepath = path.resolve(dir, filename);
 
   try {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 
 Object.defineProperty(exports, 'commentRegex', {
   get: function getCommentRegex () {
-    return /^\s*\/(?:\/|\*)[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,(?:.*)$/mg;
+    return /^\s*\/(?:\/|\*)[@#]\s+sourceMappingURL=(data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,(?:.*))$/mg;
   }
 });
 
@@ -133,4 +133,23 @@ exports.removeMapFileComments = function (src) {
 exports.generateMapFileComment = function (file, options) {
   var data = 'sourceMappingURL=' + file;
   return options && options.multiline ? '/*# ' + data + ' */' : '//# ' + data;
+};
+
+exports.getCommentValue = function (src) {
+  var comment = exports.commentRegex.exec(src);
+  if (comment && comment[1]) {
+    return comment[1];
+  }
+  return null;
+};
+
+exports.getMapFileCommentValue = function(src) {
+  var mapFileComment = exports.mapFileCommentRegex.exec(src);
+  if (mapFileComment && mapFileComment[1]) {
+    return mapFileComment[1];
+  }
+  if (mapFileComment && mapFileComment[2]) {
+    return mapFileComment[2];
+  }
+  return null;
 };

--- a/test/convert-source-map.js
+++ b/test/convert-source-map.js
@@ -253,3 +253,87 @@ test('mapFileCommentRegex returns new RegExp on each get', function(t) {
 
   t.end()
 })
+
+test('get value of a comment', function(t) {
+  var foo = [
+      'function foo() {'
+    , ' console.log("hello I am foo");'
+    , ' console.log("who are you");'
+    , '}'
+    , ''
+    , 'foo();'
+    , ''
+    ].join('\n')
+  , map = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmdW5jdGlvbiBmb28oKSB7XG4gY29uc29sZS5sb2coXCJoZWxsbyBJIGFtIGZvb1wiKTtcbiBjb25zb2xlLmxvZyhcIndobyBhcmUgeW91XCIpO1xufVxuXG5mb28oKTtcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9'
+  , expected = 'data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmdW5jdGlvbiBmb28oKSB7XG4gY29uc29sZS5sb2coXCJoZWxsbyBJIGFtIGZvb1wiKTtcbiBjb25zb2xlLmxvZyhcIndobyBhcmUgeW91XCIpO1xufVxuXG5mb28oKTtcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9'
+
+  t.equal(
+    convert.getCommentValue(foo + map),
+    expected,
+    'returns only the base64 portion of the sourceMappingURL comment'
+  )
+
+  t.equal(
+    convert.getCommentValue(foo),
+    null,
+    'returns null if no comment'
+  )
+
+  t.end()
+})
+
+test('get value of a mapFileComment with //', function(t) {
+  var foo = [
+      'function foo() {'
+    , ' console.log("hello I am foo");'
+    , ' console.log("who are you");'
+    , '}'
+    , ''
+    , 'foo();'
+    , ''
+    ].join('\n')
+  , map = '//# sourceMappingURL=foo.js.map'
+  , expected = 'foo.js.map'
+
+  t.equal(
+    convert.getMapFileCommentValue(foo + map),
+    expected,
+    'returns only the filepath of the sourceMappingURL comment'
+  )
+
+  t.equal(
+    convert.getMapFileCommentValue(foo),
+    null,
+    'returns null if no mapFileComment'
+  )
+
+  t.end()
+})
+
+test('get value of a mapFileComment with /**/', function(t) {
+  var foo = [
+      'function foo() {'
+    , ' console.log("hello I am foo");'
+    , ' console.log("who are you");'
+    , '}'
+    , ''
+    , 'foo();'
+    , ''
+    ].join('\n')
+  , map = '/*# sourceMappingURL=foo.js.map */'
+  , expected = 'foo.js.map'
+
+  t.equal(
+    convert.getMapFileCommentValue(foo + map),
+    expected,
+    'returns only the filepath of the sourceMappingURL comment'
+  )
+
+  t.equal(
+    convert.getMapFileCommentValue(foo),
+    null,
+    'returns null if no mapFileComment'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
@thlorenz I'm finding the need for these methods in some code I'm writing.  I was trying to do the regexp dance in my code but found that `commentRegex` didn't have a capture group so I figured it'd be nice to just have the APIs built-in while I was making that change.  I'm open to changing the method names, but couldn't think of a more descriptive name.

Thoughts?