### PR TITLE
Removes deprecated Buffer constructor, for 5.10.0 Class Method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
-var buffer = require('safe-buffer');
+var SafeBuffer = require('safe-buffer');
 
 Object.defineProperty(exports, 'commentRegex', {
   get: function getCommentRegex () {
@@ -18,7 +18,7 @@ Object.defineProperty(exports, 'mapFileCommentRegex', {
 
 
 function decodeBase64(base64) {
-  return buffer.Buffer.from(base64, 'base64').toString();
+  return SafeBuffer.Buffer.from(base64, 'base64').toString();
 }
 
 function stripComment(sm) {
@@ -58,7 +58,7 @@ Converter.prototype.toJSON = function (space) {
 
 Converter.prototype.toBase64 = function () {
   var json = this.toJSON();
-  return buffer.Buffer.from(json, 'utf8').toString('base64');
+  return SafeBuffer.Buffer.from(json, 'utf8').toString('base64');
 };
 
 Converter.prototype.toComment = function (options) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
+var buffer = require('safe-buffer');
 
 Object.defineProperty(exports, 'commentRegex', {
   get: function getCommentRegex () {
@@ -17,7 +18,7 @@ Object.defineProperty(exports, 'mapFileCommentRegex', {
 
 
 function decodeBase64(base64) {
-  return new Buffer(base64, 'base64').toString();
+  return buffer.Buffer.from(base64, 'base64').toString();
 }
 
 function stripComment(sm) {
@@ -57,7 +58,7 @@ Converter.prototype.toJSON = function (space) {
 
 Converter.prototype.toBase64 = function () {
   var json = this.toJSON();
-  return Buffer.from(json).toString('base64');
+  return buffer.Buffer.from(json, 'utf8').toString('base64');
 };
 
 Converter.prototype.toComment = function (options) {

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ Converter.prototype.toJSON = function (space) {
 
 Converter.prototype.toBase64 = function () {
   var json = this.toJSON();
-  return new Buffer(json).toString('base64');
+  return Buffer.from(json).toString('base64');
 };
 
 Converter.prototype.toComment = function (options) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "MIT",
   "engine": {
-    "node": ">=0.6"
+    "node": ">=5.10.0"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/thlorenz/convert-source-map",
   "dependencies": {
-    "safe-buffer": "^5.1.1"
+    "safe-buffer": "~5.1.1"
   },
   "devDependencies": {
     "inline-source-map": "~0.6.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "url": "git://github.com/thlorenz/convert-source-map.git"
   },
   "homepage": "https://github.com/thlorenz/convert-source-map",
-  "dependencies": {},
+  "dependencies": {
+    "safe-buffer": "^5.1.1"
+  },
   "devDependencies": {
     "inline-source-map": "~0.6.2",
     "tap": "~9.0.0"
@@ -31,7 +33,7 @@
   },
   "license": "MIT",
   "engine": {
-    "node": ">=5.10.0"
+    "node": ">=0.6"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Needs more recent Node.js to run, but avoid `DeprecationWarning`s.
```
(node:13) [DEP0005] DeprecationWarning: The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.
    at showFlaggedDeprecation (buffer.js:127:13)
    at new Buffer (buffer.js:148:3)
    at Converter.toBase64 (/var/app/current/node_modules/convert-source-map/index.js:60:10)
    at Converter.toComment (/var/app/current/node_modules/convert-source-map/index.js:64:21)
```

From:

https://nodejs.org/docs/latest-v6.x/api/buffer.html#buffer_new_buffer_string_encoding

`new Buffer(string)`

Stability: 0 - Deprecated: Use `Buffer.from(string[, encoding])` instead.

To:

https://nodejs.org/docs/latest-v6.x/api/buffer.html#buffer_class_method_buffer_from_string_encoding

Class Method: `Buffer.from(string[, encoding])`

Added in: v5.10.0