### PR TITLE
https://github.com/thlorenz/convert-source-map/issues/66

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var SafeBuffer = require('safe-buffer');
 
 Object.defineProperty(exports, 'commentRegex', {
   get: function getCommentRegex () {
-    return /^\s*\/(?:\/|\*)[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,(?:.*)$/mg;
+    return /\/(?:\/|\*)[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,(?:.*)$/mg;
   }
 });
 


### PR DESCRIPTION
Nodejs/ts-node/TypeScript/Mocha/IstanbulJS stack sometimes generates js files where source map comment does not start from the beginning of line and because of that could not be detected by the regex.
This causes sourcemap url to be passed as file name and throwing long file name exception.