### PR TITLE
Ignore the fs module in browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   },
   "files": [
     "index.js"
-  ]
+  ],
+  "browser": {
+    "fs": false
+  }
 }


### PR DESCRIPTION
This will make webpack and other bundlers to ignore `fs` module when creating a browser build. This library is used by `@babel/core` and `@babel/standalone`. Babel can operate in the browser environment (with some limitations) but it has to mock out the `fs` and this library is the main reason why. 

This PR brings this mock on the library level so it doesn't have to be done on the consumer's side.

Admittedly, It's a bit workaround. The fs module is needed only when `opts.isFileComment` is set. A better solution would be to split this library into multiple files so browser env libraries could use the most of its functionality without mocking fs but that would be an invasive operation and should be rather driven by maintainers if they agree.

The [Babel issue](https://github.com/babel/babel/pull/10642) for more context.