### PR TITLE
updated index.js  for error facing on unit testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ Object.defineProperty(exports, 'mapFileCommentRegex', {
 
 
 function decodeBase64(base64) {
-  return SafeBuffer.Buffer.from(base64, 'base64').toString();
+  return (SafeBuffer.Buffer.from(base64, 'base64') || "").toString();
 }
 
 function stripComment(sm) {
@@ -58,7 +58,7 @@ Converter.prototype.toJSON = function (space) {
 
 Converter.prototype.toBase64 = function () {
   var json = this.toJSON();
-  return SafeBuffer.Buffer.from(json, 'utf8').toString('base64');
+  return (SafeBuffer.Buffer.from(json, 'utf8') || "").toString('base64');
 };
 
 Converter.prototype.toComment = function (options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-source-map",
-  "version": "1.7.1",
+  "version": "1.7.0",
   "description": "Converts a source-map from/to  different formats and allows adding/changing properties.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-source-map",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Converts a source-map from/to  different formats and allows adding/changing properties.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In some unit test getting error in base64 function
`Cannot read property 'toString' of undefined`
due to some reason babel not providing source map of few unit test which lead to this error. its just an update for passing those test.
i didn't found any impact area in it. but Most welcome with the constructive feedbacks.