### PR TITLE
fix: Replace SafeBuffer with Buffer, support BASE64 in the browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,14 @@ if (typeof Buffer !== 'undefined') {
 function decodeBase64WithBufferFrom(base64) {
   return Buffer.from(base64, 'base64').toString();
 }
+
 function decodeBase64WithNewBuffer(base64) {
   if (typeof value === 'number') {
     throw new TypeError('The value to decode must not be of type number.');
   }
   return new Buffer(base64, 'base64').toString();
 }
+
 function decodeBase64WithAtob(base64) {
   return decodeURIComponent(escape(atob(base64)));
 }
@@ -88,6 +90,7 @@ function encodeBase64WithBufferFrom() {
   var json = this.toJSON();
   return Buffer.from(json, 'utf8').toString('base64');
 }
+
 function encodeBase64WithNewBuffer() {
   var json = this.toJSON();
   if (typeof json === 'number') {
@@ -95,6 +98,7 @@ function encodeBase64WithNewBuffer() {
   }
   return new Buffer(json, 'utf8').toString('base64');
 }
+
 function encodeBase64WithBtoa() {
   var json = this.toJSON();
   return btoa(unescape(encodeURIComponent(json)));

--- a/index.js
+++ b/index.js
@@ -15,16 +15,29 @@ Object.defineProperty(exports, 'mapFileCommentRegex', {
   }
 });
 
-var decodeBase64 = typeof Buffer !== 'undefined' ? Buffer.from ?
-  function decodeBase64(base64) {
-    return Buffer.from(base64, 'base64').toString();
-  } :
-  function decodeBase64(base64) {
-    return new Buffer(base64, 'base64').toString();
-  } :
-  function decodeBase64(base64) {
-    return decodeURIComponent(escape(atob(base64)));
-  };
+var decodeBase64;
+if (typeof Buffer !== 'undefined') {
+  if (typeof Buffer.from === 'function') {
+    decodeBase64 = decodeBase64WithBufferFrom;
+  } else {
+    decodeBase64 = decodeBase64WithNewBuffer;
+  }
+} else {
+  decodeBase64 = decodeBase64WithAtob;
+}
+
+function decodeBase64WithBufferFrom(base64) {
+  return Buffer.from(base64, 'base64').toString();
+}
+function decodeBase64WithNewBuffer(base64) {
+  if (typeof value === 'number') {
+    throw new TypeError('The value to decode must not be of type number.');
+  }
+  return new Buffer(base64, 'base64').toString();
+}
+function decodeBase64WithAtob(base64) {
+  return decodeURIComponent(escape(atob(base64)));
+}
 
 function stripComment(sm) {
   return sm.split(',').pop();

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "url": "git://github.com/thlorenz/convert-source-map.git"
   },
   "homepage": "https://github.com/thlorenz/convert-source-map",
-  "dependencies": {
-    "safe-buffer": "~5.1.1"
-  },
   "devDependencies": {
     "inline-source-map": "~0.6.2",
     "tap": "~9.0.0"


### PR DESCRIPTION
This is a part of changes to get this module usable in the web browser
and more lightweight at the same time.

* Remove the safe-buffer dependency. Use the Buffer constructor and
  Buffer.from depending on what is available.
* Use atob/btoa with a workaround for UTF-8 in the browser.

Fixes #70 without dropping the compatibility with Node.js 0.10.