### PR TITLE
feat: Replace mapFileDir argument with a function for reading the source map 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ console.log(json);
 
 ```js
 var convert = require('convert-source-map');
-var fs = require('fs/promises'); // Notice the `fs/promises` import
+const { promises: fs } = require('fs'); // Notice the `promises` import
 
 function readMap(filename) {
   return fs.readFile(filename, 'utf8');

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ console.log(json);
 
 ```js
 var convert = require('convert-source-map');
-const { promises: fs } = require('fs'); // Notice the `promises` import
+var { promises: fs } = require('fs'); // Notice the `promises` import
 
 function readMap(filename) {
   return fs.readFile(filename, 'utf8');

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ console.log(modified);
 {"version":3,"file":"build/foo.min.js","sources":["SRC/FOO.JS"],"names":[],"mappings":"AAAA","sourceRoot":"/"}
 ```
 
+## Upgrading
+
+Prior to v2.0.0, the `fromMapFileComment` and `fromMapFileSource` functions took a String directory path and used that to resolve & read the source map file from the filesystem. However, this made the library limited to nodejs environments and broke on sources with querystrings.
+
+In v2.0.0, you now need to pass a function that does the file reading. It will receive the source filename as a String that you can resolve to a filesystem path, URL, or anything else.
+
+If you are using `convert-source-map` in nodejs and want the previous behavior, you'll use a function like such:
+
+```diff
++ var fs = require('fs'); // Import the fs module to read a file
++ var path = require('path'); // Import the path module to resolve a path against your directory
+- var conv = convert.fromMapFileSource(css, '../my-dir');
++ var conv = convert.fromMapFileSource(css, function (filename) {
++   return fs.readFileSync(path.resolve('../my-dir', filename), 'utf-8');
++ });
+```
+
 ## API
 
 ### fromObject(obj)

--- a/README.md
+++ b/README.md
@@ -45,88 +45,78 @@ Returns source map converter from given base64 encoded json string.
 
 Returns source map converter from given base64 or uri encoded json string prefixed with `//# sourceMappingURL=...`.
 
-### fromMapFileComment(comment, mapFileDir, readMap)
+### fromMapFileComment(comment, readMap)
 
 Returns source map converter from given `filename` by parsing `//# sourceMappingURL=filename`.
 
-`filename` must point to a file that is found inside the `mapFileDir`. Most tools store this file right next to the
-generated file, i.e. the one containing the source map.
+`readMap` must be a function which receives the source map filename and returns either a String or Buffer of the source map (if read synchronously), or a `Promise` containing a String or Buffer of the source map (if read asynchronously).
 
-`readMap` must be a `function (filepath)`, which returns either a string with the source map read from the file synchronously, or a `Promise` if the source map will be read asynchronously. If `readMap` returns string, `fromMapFileComment` will return a source map converter and other methods from its interface will be chainable. If `readMap` returns a `Promise`, `fromMapFileComment` will return a `Promise` too and the next access to the source map converter will need to be handled asynchronously. The `Promise` will be either resolved with the source map converter or rejected with an error. The only method required from a `Promise` instance returned by `readMap` is `then(success, error)`; not the full standard.
+If `readMap` doesn't return a `Promise`, `fromMapFileComment` will return a source map converter synchronously.
 
-For example, a synchronous way in Node.js:
+If `readMap` returns a `Promise`, `fromMapFileComment` will also return `Promise`. The `Promise` will be either resolved with the source map converter or rejected with an error.
+
+#### Examples
+
+**Synchronous read in Node.js:**
 
 ```js
 var convert = require('convert-source-map');
 var fs = require('fs');
 
-function readMap(filepath) {
-  return fs.readFileSync(filepath, 'utf8');
+function readMap(filename) {
+  return fs.readFileSync(filename, 'utf8');
 }
 
 var json = convert
-  .fromMapFileComment('//# sourceMappingURL=map-file-comment.css.map', '.', readMap)
+  .fromMapFileComment('//# sourceMappingURL=map-file-comment.css.map', readMap)
   .toJSON();
 console.log(json);
 ```
 
 
-For example, an asynchronous way in Node.js:
+**Asynchronous read in Node.js:**
 
 ```js
 var convert = require('convert-source-map');
-var fs = require('fs');
+var fs = require('fs/promises'); // Notice the `fs/promises` import
 
-function readMap(filepath) {
-  return fs.readFile(filepath, 'utf8');
+function readMap(filename) {
+  return fs.readFile(filename, 'utf8');
 }
 
-var converter = await convert.fromMapFileComment('//# sourceMappingURL=map-file-comment.css.map', '.', readMap)
+var converter = await convert.fromMapFileComment('//# sourceMappingURL=map-file-comment.css.map', readMap)
 var json = converter.toJSON();
 console.log(json);
 ```
 
-For example, an asynchronous way in the browser:
+**Asynchronous read in the browser:**
 
 ```js
 var convert = require('convert-source-map');
 
-function readMap(url) {
-  return new Promise(function (resolve, reject) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true);
-    xhr.onreadystatechange = onreadystatechange;
-    xhr.send(null)
-
-    function onreadystatechange() {
-      if (xhr.readyState !== 4 return;
-      if (xhr.status === 200) resolve(xhr.responseText);
-      else reject(new Error(xhr.statusText));
-    }
-  });
+async function readMap(url) {
+  const res = await fetch(url);
+  return res.text();
 }
 
-convert
-  .fromMapFileComment('//# sourceMappingURL=map-file-comment.css.map', '/assets', readMap)
-  .then(function (converter) {
-    var json = converter.toJSON();
-    console.log(json);
-  }, function (error) {
-    console.error(error);
-  });
+const converter = await convert.fromMapFileComment('//# sourceMappingURL=map-file-comment.css.map', readMap)
+var json = converter.toJSON();
+console.log(json);
 ```
 
 ### fromSource(source)
 
 Finds last sourcemap comment in file and returns source map converter or returns `null` if no source map comment was found.
 
-### fromMapFileSource(source, mapFileDir, readMap)
+### fromMapFileSource(source, readMap)
 
-Finds last sourcemap comment in file and returns source map converter or returns `null` if no source map comment was
-found.
+Finds last sourcemap comment in file and returns source map converter or returns `null` if no source map comment was found.
 
-The sourcemap will be read from the map file found by parsing `# sourceMappingURL=file` comment. For more info see
-fromMapFileComment.
+`readMap` must be a function which receives the source map filename and returns either a String or Buffer of the source map (if read synchronously), or a `Promise` containing a String or Buffer of the source map (if read asynchronously).
+
+If `readMap` doesn't return a `Promise`, `fromMapFileSource` will return a source map converter synchronously.
+
+If `readMap` returns a `Promise`, `fromMapFileSource` will also return `Promise`. The `Promise` will be either resolved with the source map converter or rejected with an error.
 
 ### toObject()
 

--- a/index.js
+++ b/index.js
@@ -186,6 +186,13 @@ function makeConverter(sm) {
 }
 
 exports.fromMapFileComment = function (comment, read) {
+  if (typeof read === 'string') {
+    throw new Error(
+      'String directory paths are no longer supported with `fromMapFileComment`\n' +
+      'Please review the Upgrading documentation at https://github.com/thlorenz/convert-source-map#upgrading'
+    )
+  }
+
   var sm = readFromFileMap(comment, read);
   if (sm != null && typeof sm.then === 'function') {
     return sm.then(makeConverter);
@@ -202,6 +209,12 @@ exports.fromSource = function (content) {
 
 // Finds last sourcemap comment in file or returns null if none was found
 exports.fromMapFileSource = function (content, read) {
+  if (typeof read === 'string') {
+    throw new Error(
+      'String directory paths are no longer supported with `fromMapFileSource`\n' +
+      'Please review the Upgrading documentation at https://github.com/thlorenz/convert-source-map#upgrading'
+    )
+  }
   var m = content.match(exports.mapFileCommentRegex);
   return m ? exports.fromMapFileComment(m.pop(), read) : null;
 };

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function readFromFileMap(sm, read) {
   }
 
   function throwError(e) {
-    throw new Error('An error occurred while trying to read the map file at ' + filename + '\n' + e);
+    throw new Error('An error occurred while trying to read the map file at ' + filename + '\n' + e.stack);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
   },
   "files": [
     "index.js"
-  ],
-  "browser": {
-    "fs": false
-  }
+  ]
 }

--- a/test/map-file-comment.js
+++ b/test/map-file-comment.js
@@ -4,24 +4,46 @@
 var test = require('tap').test
   , rx = require('..')
   , fs = require('fs')
+  , path = require('path')
   , convert = require('..')
 
-function readMapSync(filepath) {
-  return fs.readFileSync(filepath, 'utf8');
+function readMapSyncString(filename) {
+  var filepath = path.join(__dirname, 'fixtures', filename)
+  return fs.readFileSync(filepath, 'utf-8')
+}
+function readMapSyncBuffer(filename) {
+  var filepath = path.join(__dirname, 'fixtures', filename)
+  return fs.readFileSync(filepath)
 }
 
-function readMapAsync(filepath) {
+function readMapAsyncString(filename) {
   return new Promise(function (resolve, reject) {
+    var filepath = path.join(__dirname, 'fixtures', filename)
     fs.readFile(filepath, 'utf8', function (err, content) {
-      if (err) reject(err);
-      else resolve(content);
-    });
-  });
+      if (err) {
+        reject(err)
+      } else {
+        resolve(content)
+      }
+    })
+  })
+}
+function readMapAsyncBuffer(filename) {
+  return new Promise(function (resolve, reject) {
+    var filepath = path.join(__dirname, 'fixtures', filename)
+    fs.readFile(filepath, function (err, content) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(content)
+      }
+    })
+  })
 }
 
 test('\nresolving a "/*# sourceMappingURL=map-file-comment.css.map*/" style comment inside a given css content', function (t) {
   var css = fs.readFileSync(__dirname + '/fixtures/map-file-comment.css', 'utf8')
-  var conv = convert.fromMapFileSource(css, __dirname + '/fixtures', readMapSync);
+  var conv = convert.fromMapFileSource(css, readMapSyncString);
   var sm = conv.toObject();
 
   t.deepEqual(
@@ -42,7 +64,49 @@ test('\nresolving a "/*# sourceMappingURL=map-file-comment.css.map*/" style comm
 
 test('\nresolving a "//# sourceMappingURL=map-file-comment.css.map" style comment inside a given css content', function (t) {
   var css = fs.readFileSync(__dirname + '/fixtures/map-file-comment-double-slash.css', 'utf8')
-  var conv = convert.fromMapFileSource(css, __dirname + '/fixtures', readMapSync);
+  var conv = convert.fromMapFileSource(css, readMapSyncString);
+  var sm = conv.toObject();
+
+  t.deepEqual(
+      sm.sources
+    , [ './client/sass/core.scss',
+        './client/sass/main.scss' ]
+    , 'resolves paths of original sources'
+  )
+
+  t.equal(sm.file, 'map-file-comment.css', 'includes filename of generated file')
+  t.equal(
+      sm.mappings
+    , 'AAAA,wBAAyB;EACvB,UAAU,EAAE,IAAI;EAChB,MAAM,EAAE,KAAK;EACb,OAAO,EAAE,IAAI;EACb,aAAa,EAAE,iBAAiB;EAChC,KAAK,EAAE,OAAkB;;AAG3B,wBAAyB;EACvB,OAAO,EAAE,IAAI;;ACTf,gBAAiB;EACf,UAAU,EAAE,IAAI;EAChB,KAAK,EAAE,MAAM;;AAGf,kBAAmB;EACjB,MAAM,EAAE,IAAI;EACZ,OAAO,EAAE,IAAI;EACb,UAAU,EAAE,KAAK;EACjB,aAAa,EAAE,GAAG;EAClB,KAAK,EAAE,KAAK;;AAEd,kBAAmB;EACjB,KAAK,EAAE,KAAK;;AAGd,mBAAoB;EAClB,KAAK,EAAE,KAAK;EACZ,MAAM,EAAE,IAAI;EACZ,OAAO,EAAE,IAAI;EACb,SAAS,EAAE,IAAI'
+    , 'includes mappings'
+  )
+  t.end()
+})
+
+test('\nresolving a "/*# sourceMappingURL=map-file-comment.css.map*/" style comment inside a given css content', function (t) {
+  var css = fs.readFileSync(__dirname + '/fixtures/map-file-comment.css', 'utf8')
+  var conv = convert.fromMapFileSource(css, readMapSyncBuffer);
+  var sm = conv.toObject();
+
+  t.deepEqual(
+      sm.sources
+    , [ './client/sass/core.scss',
+        './client/sass/main.scss' ]
+    , 'resolves paths of original sources'
+  )
+
+  t.equal(sm.file, 'map-file-comment.css', 'includes filename of generated file')
+  t.equal(
+      sm.mappings
+    , 'AAAA,wBAAyB;EACvB,UAAU,EAAE,IAAI;EAChB,MAAM,EAAE,KAAK;EACb,OAAO,EAAE,IAAI;EACb,aAAa,EAAE,iBAAiB;EAChC,KAAK,EAAE,OAAkB;;AAG3B,wBAAyB;EACvB,OAAO,EAAE,IAAI;;ACTf,gBAAiB;EACf,UAAU,EAAE,IAAI;EAChB,KAAK,EAAE,MAAM;;AAGf,kBAAmB;EACjB,MAAM,EAAE,IAAI;EACZ,OAAO,EAAE,IAAI;EACb,UAAU,EAAE,KAAK;EACjB,aAAa,EAAE,GAAG;EAClB,KAAK,EAAE,KAAK;;AAEd,kBAAmB;EACjB,KAAK,EAAE,KAAK;;AAGd,mBAAoB;EAClB,KAAK,EAAE,KAAK;EACZ,MAAM,EAAE,IAAI;EACZ,OAAO,EAAE,IAAI;EACb,SAAS,EAAE,IAAI'
+    , 'includes mappings'
+  )
+  t.end()
+})
+
+test('\nresolving a "//# sourceMappingURL=map-file-comment.css.map" style comment inside a given css content', function (t) {
+  var css = fs.readFileSync(__dirname + '/fixtures/map-file-comment-double-slash.css', 'utf8')
+  var conv = convert.fromMapFileSource(css, readMapSyncBuffer);
   var sm = conv.toObject();
 
   t.deepEqual(
@@ -63,7 +127,33 @@ test('\nresolving a "//# sourceMappingURL=map-file-comment.css.map" style commen
 
 test('\nresolving a "//# sourceMappingURL=map-file-comment.css.map" style comment asynchronously', function (t) {
   var css = fs.readFileSync(__dirname + '/fixtures/map-file-comment-double-slash.css', 'utf8')
-  var promise = convert.fromMapFileSource(css, __dirname + '/fixtures', readMapAsync);
+  var promise = convert.fromMapFileSource(css, readMapAsyncString);
+  promise.then(function (conv) {
+    var sm = conv.toObject();
+
+    t.deepEqual(
+        sm.sources
+      , [ './client/sass/core.scss',
+          './client/sass/main.scss' ]
+      , 'resolves paths of original sources'
+    )
+
+    t.equal(sm.file, 'map-file-comment.css', 'includes filename of generated file')
+    t.equal(
+        sm.mappings
+      , 'AAAA,wBAAyB;EACvB,UAAU,EAAE,IAAI;EAChB,MAAM,EAAE,KAAK;EACb,OAAO,EAAE,IAAI;EACb,aAAa,EAAE,iBAAiB;EAChC,KAAK,EAAE,OAAkB;;AAG3B,wBAAyB;EACvB,OAAO,EAAE,IAAI;;ACTf,gBAAiB;EACf,UAAU,EAAE,IAAI;EAChB,KAAK,EAAE,MAAM;;AAGf,kBAAmB;EACjB,MAAM,EAAE,IAAI;EACZ,OAAO,EAAE,IAAI;EACb,UAAU,EAAE,KAAK;EACjB,aAAa,EAAE,GAAG;EAClB,KAAK,EAAE,KAAK;;AAEd,kBAAmB;EACjB,KAAK,EAAE,KAAK;;AAGd,mBAAoB;EAClB,KAAK,EAAE,KAAK;EACZ,MAAM,EAAE,IAAI;EACZ,OAAO,EAAE,IAAI;EACb,SAAS,EAAE,IAAI'
+      , 'includes mappings'
+    )
+    t.end()
+  }, function (err) {
+    t.error(err, 'read map');
+    t.end()
+  });
+})
+
+test('\nresolving a "//# sourceMappingURL=map-file-comment.css.map" style comment asynchronously', function (t) {
+  var css = fs.readFileSync(__dirname + '/fixtures/map-file-comment-double-slash.css', 'utf8')
+  var promise = convert.fromMapFileSource(css, readMapAsyncBuffer);
   promise.then(function (conv) {
     var sm = conv.toObject();
 
@@ -89,7 +179,7 @@ test('\nresolving a "//# sourceMappingURL=map-file-comment.css.map" style commen
 
 test('\nresolving a /*# sourceMappingURL=data:application/json;base64,... */ style comment inside a given css content', function(t) {
   var css = fs.readFileSync(__dirname + '/fixtures/map-file-comment-inline.css', 'utf8')
-  var conv = convert.fromSource(css, __dirname + '/fixtures')
+  var conv = convert.fromSource(css)
   var sm = conv.toObject()
 
   t.deepEqual(


### PR DESCRIPTION
This is a part of changes to get this module usable in the web browser
by not depending on any Node.js modules.

* Remove the fs and path dependencies.
* Expect a function for reading the source map content to be passed as a parameter.
* Concatenate directory and file names without path.resolve.
* Behave synchronously or asynchronously depending if the source map reading method
  returned a string or a promise resolving to string.

BREAKING CHANGE: Methods fromMapFileComment and fromMapFileSource
                 require an additional parameter - readMap - to
		 read the source map content. They behave synchronously
		 or asynchronously depending on the behaviour
		 of the readMap function.

Fixes #64 with a breaking change on the API.