### PR TITLE
feat: Replace Travis-CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [pull_request, push]
 env:
   CI: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [0.10, 0.12, 4, 6, 8, 10, 12, 14, 16, 18]
+        node: ["0.10", "0.12", "4", "6", "8", "10", "12", "14", "16", "18"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+env:
+  CI: true
+
+jobs:
+  test:
+    name: Tests for Node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [0.10, 0.12, 4, 6, 8, 10, 12, 14, 16, 18]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "6"
-  - "node"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# convert-source-map [![build status](https://secure.travis-ci.org/thlorenz/convert-source-map.svg?branch=master)](http://travis-ci.org/thlorenz/convert-source-map)
+# convert-source-map [![Build Status][ci-image]][ci-url]
 
 Converts a source-map from/to  different formats and allows adding/changing properties.
 
@@ -118,3 +118,6 @@ Returns a comment that links to an external source map via `file`.
 By default, the comment is formatted like: `//# sourceMappingURL=...`, which you would normally see in a JS source file.
 
 When `options.multiline == true`, the comment is formatted like: `/*# sourceMappingURL=... */`, which you would find in a CSS source file.
+
+[ci-url]: https://github.com/gulpjs/vinyl-sourcemap/actions?query=workflow:ci
+[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/vinyl-sourcemap/ci?style=flat-square


### PR DESCRIPTION
Travis-CI has been poorly managed and been targeted by malicious actors since the original company sold it. This replaces it with GitHub Actions for CI.

Closes #72 (replaces it since travis is dropped)