### PR TITLE
chore!: Drop support for node below v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["0.10", "0.12", "4", "6", "8", "10", "12", "14", "16", "18"]
+        node: ["4", "6", "8", "10", "12", "14", "16", "18"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "engine": {
-    "node": ">=0.6"
+    "node": ">=4"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
This is a breaking change that drops support for nodejs below v4 - the older node versions were extremely flakey on Windows and this reduces some headaches around re-running CI.

We shouldn't merge this until v1.9 of convert-source-map is released