### PR TITLE
Rewrite regular expressions to limit catastrophic backtracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, 'commentRegex', {
   get: function getCommentRegex () {
     // Groups: 1: media type, 2: MIME type, 3: charset, 4: encoding, 5: data.
-    return /^\s*?\/[\/\*][@#]\s+?sourceMappingURL=data:(((?:application|text)\/json)(?:;charset=([^;,]+?)?)?)?(?:;(base64))?,(.*?)$/mg;
+    return /^(?:[ \t\f\v]*?)\/[\/\*][@#]\s+sourceMappingURL=data:(((?:application|text)\/json)(?:;charset=([^;,]+?))?)?(?:;(base64))?,(.*?)$/mg;
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ Object.defineProperty(exports, 'commentRegex', {
 Object.defineProperty(exports, 'mapFileCommentRegex', {
   get: function getMapFileCommentRegex () {
     // Matches sourceMappingURL in either // or /* comment styles.
-    return /(?:\/\/[@#][ \t]+?sourceMappingURL=([^\s'"`]+?)[ \t]*?$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^*]+?)[ \t]*?(?:\*\/){1}[ \t]*?$)/mg;
+    return /(?:\/\/[@#]\s+sourceMappingURL=([^\s'"`]+)\s*$)|(?:\/\*[@#]\s+sourceMappingURL=([^\s*]+)\s*\*\/)[ \t]*$/mg;
   }
 });
 
@@ -47,7 +47,7 @@ function stripComment(sm) {
 
 function readFromFileMap(sm, read) {
   var r = exports.mapFileCommentRegex.exec(sm);
-  // for some odd reason //# .. captures in 1 and /* .. */ in 2
+  // "//# .." capture in group 1 and "/*# .. */" in group 2 due to alternate (|) operator in regular expression
   var filename = r[1] || r[2];
 
   try {


### PR DESCRIPTION
Also explains why capture groups 1/2 are used.